### PR TITLE
DEVPROD-9384: use custom project change event unmarshaller

### DIFF
--- a/migrations/redactProjectEventVariables.go
+++ b/migrations/redactProjectEventVariables.go
@@ -134,17 +134,14 @@ func (c *redactProjectEventSecrets) redactForProject(ctx context.Context, client
 	}
 
 	for cur.Next(ctx) {
-		var e event.EventLogEntry
+		var e model.ProjectChangeEventEntry
 		if err := cur.Decode(&e); err != nil {
 			return errors.Wrap(err, "decoding event")
 		}
 
 		// Redact the project secrets from the event.
-		changeEvent := model.ProjectChangeEventEntry{
-			EventLogEntry: e,
-		}
-		changeEvents := model.ProjectChangeEvents{changeEvent}
-		changeEvents.RedactSecrets()
+		changeEvent := model.ProjectChangeEvents{e}
+		changeEvent.RedactSecrets()
 
 		eventData, ok := e.Data.(*model.ProjectChangeEvent)
 		if !ok {


### PR DESCRIPTION
DEVPROD-9384

I ran the job on one project in staging and it hit an error decoding the event. Apparently, project change events are special and have a [custom BSON unmarshalling implementation](https://github.com/evergreen-ci/evergreen/blob/main/model/project_event.go#L251-L255), which is ever so slightly different from [the one for generic event log entries](https://github.com/evergreen-ci/evergreen/blob/3e97e565fadb2db8e2bba635b132a4eb99ef4e4d/model/event/event.go#L73-L79). I don't really understand why project change events need to be a special case, but I modified the logic to use the special unmarshaller.