### PR TITLE
DEVPROD-9384: use correct vars field

### DIFF
--- a/migrations/redactProjectEventVariables.go
+++ b/migrations/redactProjectEventVariables.go
@@ -153,10 +153,10 @@ func (c *redactProjectEventSecrets) redactForProject(ctx context.Context, client
 
 		setFields := bson.M{}
 		if len(eventData.Before.Vars.Vars) > 0 {
-			setFields["data.before.vars.vars"] = eventData.Before.Vars
+			setFields["data.before.vars.vars"] = eventData.Before.Vars.Vars
 		}
 		if len(eventData.After.Vars.Vars) > 0 {
-			setFields["data.after.vars.vars"] = eventData.After.Vars
+			setFields["data.after.vars.vars"] = eventData.After.Vars.Vars
 		}
 		if len(eventData.Before.GitHubAppAuth.PrivateKey) > 0 {
 			setFields["data.before.github_app_auth.private_key"] = eventData.Before.GitHubAppAuth.PrivateKey


### PR DESCRIPTION
One more amendment to #3 - I accidentally used the wrong vars field when updating the event data. The migration appeared to produce the desired redaction data when I ran it on a test project in staging, I just set the wrong field.

I also added another env var option to limit the number of events modified by the job at once. That way, I can spot check a couple of events that stuff looks okay before migrating the rest of them for a project.